### PR TITLE
Curv4

### DIFF
--- a/sources/diagnos.f90
+++ b/sources/diagnos.f90
@@ -76,6 +76,10 @@ SUBROUTINE diagnos
        if(coil(icoil)%type .ne. 1) exit ! only for Fourier
        call avgcurvature(icoil)
        AvgCurv = AvgCurv + coil(icoil)%avgcurv
+#ifdef DEBUG
+     if(myid .eq. 0) write(ounit, '(8X": Average curvature of "I3 "-th coil is : " ES23.15)') &
+          icoil, coil(icoil)%avgcurv
+#endif
     enddo
     AvgCurv = AvgCurv / Ncoils
     if(myid .eq. 0) write(ounit, '(8X": Average curvature of the coils is"5X" :" ES23.15)') AvgCurv
@@ -249,7 +253,7 @@ subroutine avgcurvature(icoil)
 
   REAL,allocatable    :: davgcurv(:)
 
-  SALLOCATE(davgcurv, (0:coil(icoil)%NS), zero)
+  SALLOCATE(davgcurv, (0:coil(icoil)%NS-1), zero)
 
   davgcurv = sqrt( (coil(icoil)%za*coil(icoil)%yt-coil(icoil)%zt*coil(icoil)%ya)**2  &
              + (coil(icoil)%xa*coil(icoil)%zt-coil(icoil)%xt*coil(icoil)%za)**2  & 

--- a/sources/globals.f90
+++ b/sources/globals.f90
@@ -101,7 +101,8 @@ module globals
   INTEGER              :: case_bnormal   =   0
   INTEGER              :: case_length    =   1
   INTEGER              :: case_curv      =   1 
-  REAL                 :: curv_alpha     =   2
+  REAL                 :: curv_alpha     =   2.000D+00
+  REAL                 :: curv_c         =   1.000D-04
   REAL                 :: k0             =   0.000D+00
   REAL                 :: weight_bnorm   =   1.000D+00
   INTEGER              :: bharm_jsurf    =   0
@@ -193,6 +194,7 @@ module globals
                         case_length    , &
                         case_curv      , &
                         curv_alpha     , &
+                        curv_c         , &
                         k0             , &
                         weight_bnorm   , &
                         bharm_jsurf    , &

--- a/sources/initial.f90
+++ b/sources/initial.f90
@@ -627,6 +627,8 @@ subroutine check_input
         if (IsQuiet < 1) write(ounit, 1000) 'case_curv', case_curv, 'Quadratic format of curvature penalty.'
      case ( 3 )
         if (IsQuiet < 1) write(ounit, 1000) 'case_curv', case_curv, 'Penalty function of curvature.'
+     case ( 4 )
+        if (IsQuiet < 1) write(ounit, 1000) 'case_curv', case_curv, 'Linear and Penalty function.'
      case default
         FATAL( initial, .true., selected case_curv is not supported )
      end select

--- a/sources/length.f90
+++ b/sources/length.f90
@@ -162,7 +162,6 @@ subroutine length(ideriv)
      endif
 
      t1L = t1L / (Ncoils - Nfixgeo + machprec)
-
   endif
 
   return
@@ -174,7 +173,7 @@ end subroutine length
 
 subroutine LenDeriv0(icoil, length)
 
-  use globals, only: dp, zero, coil, myid, ounit, Ncoils, MPI_COMM_FOCUS
+  use globals, only: dp, zero, coil, myid, ounit, Ncoils, MPI_COMM_FOCUS 
   implicit none
   include "mpif.h"
 
@@ -194,7 +193,7 @@ subroutine LenDeriv0(icoil, length)
      length  = length + dlength * coil(icoil)%dd(kseg)
 
   enddo ! end kseg
-
+ 
   return
 
 end subroutine LenDeriv0

--- a/sources/rdcoils.f90
+++ b/sources/rdcoils.f90
@@ -324,7 +324,6 @@ subroutine rdcoils
         coil(icoil)%L  =  pi2*init_radius
         coil(icoil)%Lc =  IsVaryGeometry
         coil(icoil)%Lo =  target_length
-        !coil(icoil)%k0 =  k0
         write(coil(icoil)%name,'("Mod_"I3.3)') icoil
         FATAL( rdcoils, coil(icoil)%Ic < 0 .or. coil(icoil)%Ic > 1, illegal )
         FATAL( rdcoils, coil(icoil)%Lc < 0 .or. coil(icoil)%Lc > 1, illegal )


### PR DESCRIPTION
A fourth curvature objective function is implemented in FOCUS. It optimizes for the minimum radius curvature and the average curvature. It is shown empirically that coils can be optimized to satisfy the curvature constraint while reducing the magnitude of unnecessary wiggles, without significantly increasing field error. Functional derivatives are not used. Only Fourier parameterized coils can use the curvature objective functions. If another parameterization wants to use the curvature objective functions, then mixed derivatives of parameterizing variable and optimization variables would need to be implemented. Analytic derivatives have been checked against finite differences.