### PR TITLE
Update poincare plot parameters

### DIFF
--- a/sources/globals.f90
+++ b/sources/globals.f90
@@ -15,7 +15,7 @@ module globals
   
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 
-  CHARACTER(LEN=10), parameter :: version='dp_v1.2.00' ! version number
+  CHARACTER(LEN=10), parameter :: version='dp_v1.2.01' ! version number
 
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 
@@ -160,6 +160,8 @@ module globals
   REAL                 :: pp_rmax        =  0.000D+00
   REAL                 :: pp_zmax        =  0.000D+00
   INTEGER              :: pp_ns          =  10
+  INTEGER              :: pp_nsteps      =  5
+  INTEGER              :: pp_nfp         =  1
   INTEGER              :: pp_maxiter     =  1000
   REAL                 :: pp_xtol        =  1.000D-06
 
@@ -245,6 +247,8 @@ module globals
                         pp_zmax        , &
                         pp_ns          , &
                         pp_maxiter     , &
+                        pp_nsteps      , &
+                        pp_nfp         , &
                         pp_xtol
 
 


### PR DESCRIPTION
Add two more parameters for fieldline tracing for FAMUS. 
- `pp_nfp` defines the number of field periodicities. The fieldline integration will be performed between [0, 2*pi/pp_nfp]. IBy default, `pp_nfp=1`.
- `pp_nsteps` defines the number of steps during the ODE integration. If the field is integrable, `pp_nsteps =1` would be sufficient. But you might need more steps when the field is not so smooth. By default, `pp_nsteps = 5`. The more steps, the more time it takes to finish the fieldline tracing, and the more accurate the results are. 

@tmqian You might want to redo your fieldline tracing for MUSE-NCSX using `pp_nsteps=10` or so.