### PR TITLE
Magnetic axis data saved in axis_r,phi,z

### DIFF
--- a/sources/globals.f90
+++ b/sources/globals.f90
@@ -16,7 +16,7 @@ module globals
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 
 
-  CHARACTER(10), parameter :: version='v0.18.00' ! version number
+  CHARACTER(10), parameter :: version='v0.18.01' ! version number
 
 
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
@@ -238,6 +238,7 @@ module globals
   INTEGER              :: pp_nsteps      =  1
   INTEGER              :: pp_nfp         =  1
   REAL                 :: pp_xtol        =  1.000D-06
+  INTEGER              :: axis_npoints   = 360
                                                          
   namelist / focusin / &
   IsQuiet       ,&
@@ -337,7 +338,7 @@ module globals
   Nmax          ,&
   sdelta        ,&
   case_optimize ,&
-  fdiff_delta        ,&
+  fdiff_delta   ,&
   exit_tol      ,&
   DF_maxiter    ,&
   DF_xtol       ,&
@@ -376,7 +377,8 @@ module globals
   pp_maxiter    ,&
   pp_nsteps     ,&
   pp_nfp        ,&
-  pp_xtol                            
+  pp_xtol       ,&
+  axis_npoints                      
 
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
   
@@ -538,7 +540,7 @@ module globals
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
   
   ! fieldline tracing
-  REAL, ALLOCATABLE    :: XYZB(:,:,:), ppr(:,:), ppz(:,:), iota(:)
+  REAL, ALLOCATABLE    :: XYZB(:,:,:), ppr(:,:), ppz(:,:), iota(:), axis_phi(:), axis_r(:), axis_z(:)
   INTEGER              :: tor_num, total_num, booz_mpol, booz_ntor, booz_mn
   LOGICAL              :: lboozmn = .false.
   INTEGER, ALLOCATABLE :: bmim(:), bmin(:)

--- a/sources/saving.f90
+++ b/sources/saving.f90
@@ -157,6 +157,7 @@ subroutine saving
   HWRITEIV( 1                ,   pp_ns         ,   pp_ns                         )
   HWRITEIV( 1                ,   pp_maxiter    ,   pp_maxiter                    )
   HWRITERV( 1                ,   pp_xtol       ,   pp_xtol                       )
+  HWRITEIV( 1                ,   axis_npoints  ,   axis_npoints                  )
 
   HWRITEIV( 1                ,   Nfp           ,   surf(plasma)%Nfp                     )
   HWRITERV( 1                ,   surf_vol      ,   surf(plasma)%vol                     )
@@ -346,6 +347,9 @@ subroutine saving
      HWRITERA( pp_ns, pp_maxiter+1,   ppr         ,  ppr(1:pp_ns, 0:pp_maxiter) )
      HWRITERA( pp_ns, pp_maxiter+1,   ppz         ,  ppz(1:pp_ns, 0:pp_maxiter) )
      HWRITERV( pp_ns              ,   iota        ,  iota(1:pp_ns)              )
+     HWRITERV( axis_npoints       ,   axis_phi    ,  axis_phi(1:axis_npoints)   )
+     HWRITERV( axis_npoints       ,   axis_r      ,  axis_r(1:axis_npoints)     )
+     HWRITERV( axis_npoints       ,   axis_z      ,  axis_z(1:axis_npoints)     )
   endif
 
   if (allocated(XYZB)) then


### PR DESCRIPTION
The axis shape is now saved. Users can use `axis_npoints=360` to change the resolution. After successful field-line tracing, the axis shape is saved in cylindrical coordinates in the HDF5 file with names such as `axis_r`, `axis_phi`, and `axis_z`.